### PR TITLE
[Feat] Implement :after

### DIFF
--- a/assets/css/sushi.css
+++ b/assets/css/sushi.css
@@ -887,7 +887,7 @@ UL.ss-menu-woven > li.selected:after {
   width: 4px;
   border-radius: 4px;
   height: 1.25rem;
-  right: 4px;
+  right: 8px;
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
@@ -1065,14 +1065,6 @@ UL.ss-menu, UL.ss-menu-woven {
   margin: 0px;
   padding: 8px;
   gap: 4px;
-}
-
-UL.ss-menu > li.selected > a::after, UL.ss-menu-woven > li.selected > a::after {
-  content: " ";
-  position: relative;
-  background-color: #FCB034;
-  width: 4px;
-  border-radius: 2px;
 }
 
 UL.ss-menu > li > .title, UL.ss-menu-woven > li > .title {

--- a/assets/css/sushi.css
+++ b/assets/css/sushi.css
@@ -877,6 +877,21 @@ UL.ss-menu-woven > li {
 
 UL.ss-menu-woven > li.selected {
   --background: #fef3e6;
+  position: relative;
+}
+
+UL.ss-menu-woven > li.selected:after {
+  content: "";
+  position: absolute;
+  background-color: #fcb034;
+  width: 4px;
+  border-radius: 4px;
+  height: 1.25rem;
+  right: 4px;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 UL.ss-menu-woven > li:first-child {

--- a/assets/css/sushi.css
+++ b/assets/css/sushi.css
@@ -880,7 +880,7 @@ UL.ss-menu-woven > li.selected {
   position: relative;
 }
 
-UL.ss-menu-woven > li.selected:after {
+UL.ss-menu-woven > li.selected::after {
   content: "";
   position: absolute;
   background-color: #fcb034;

--- a/assets/css/sushi.css
+++ b/assets/css/sushi.css
@@ -877,21 +877,6 @@ UL.ss-menu-woven > li {
 
 UL.ss-menu-woven > li.selected {
   --background: #fef3e6;
-  position: relative;
-}
-
-UL.ss-menu-woven > li.selected::after {
-  content: "";
-  position: absolute;
-  background-color: #fcb034;
-  width: 4px;
-  border-radius: 4px;
-  height: 1.25rem;
-  right: 8px;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
 }
 
 UL.ss-menu-woven > li:first-child {
@@ -1065,6 +1050,24 @@ UL.ss-menu, UL.ss-menu-woven {
   margin: 0px;
   padding: 8px;
   gap: 4px;
+}
+
+UL.ss-menu > li, UL.ss-menu-woven > li {
+  position: relative;
+}
+
+UL.ss-menu > li.selected::after, UL.ss-menu-woven > li.selected::after {
+  content: " ";
+  position: absolute;
+  background-color: #FCB034;
+  width: 4px;
+  border-radius: 2px;
+  height: calc(100% - 8px);
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  right: 8px;
 }
 
 UL.ss-menu > li > .title, UL.ss-menu-woven > li > .title {

--- a/src/scss/components/ss-menu.scss
+++ b/src/scss/components/ss-menu.scss
@@ -26,12 +26,20 @@ UL.ss-menu {
   padding: 8px;
   gap: 4px;
 
-  > li.selected > a::after {
-    content: "\00a0";
+  > li {
     position: relative;
+  }
+
+  > li.selected::after {
+    content: "\00a0";
+    position: absolute;
     background-color: $primary-yellow;
     width: $radius;
     border-radius: calc($radius / 2);
+    height: calc(100% - 8px);
+    top: 50%;
+    transform: translateY(-50%);
+    right: 8px;
   }
 }
 


### PR DESCRIPTION
# Overview

In my opinion, the menu item could other from `<a>`, and I want selected list can be easily to implement.
So, I make selected styles to be used with just `<li>`.

# Scope of work 

Remove unused `selected-box` class and implement with `:after` on `<li>` instead of `<a>`.