### PR TITLE
NEW: [Feat] Implement :after

### DIFF
--- a/src/pug/pages/menu.pug
+++ b/src/pug/pages/menu.pug
@@ -42,6 +42,12 @@ block page-block
               a(href="javascript:void(0);")
                 span.ss-icon-Status-circle
                 span.label Menu
+            li.selected
+              a(href="javascript:void(0);")
+                span.ss-icon-Status-circle
+                span.label
+                  | Long menu label to test
+                  | two line menu
             li
               a(href="javascript:void(0);")
                 span.ss-icon-Status-circle
@@ -113,6 +119,18 @@ block page-block
                   | ชื่อยาวๆ ในเมนู ยาวๆ หลายบรรทัด
                   | จะได้เห็นว่ามันยาวได้จริงหรือเปล่า
                   | แม้แต่สี่บรรทัดก็ทำได้
+            li.selected
+              .relative
+                .line
+                  .top
+                  .background
+                  .bottom
+              a(href="javascript:void(0);")
+                .status
+                  .circle &nbsp;
+                span.label
+                  | ชื่อยาวๆ ในเมนู ยาวๆ
+                  | หลายบรรทัด
             li
               .relative
                 .line

--- a/src/scss/components/ss-menu.scss
+++ b/src/scss/components/ss-menu.scss
@@ -26,15 +26,21 @@ UL.ss-menu {
   padding: 8px;
   gap: 4px;
 
-  > li.selected > a::after {
-    content: "\00a0";
+  > li.selected {
+    --background: #fef3e6;
     position: relative;
-    background-color: $primary-yellow;
-    width: $radius;
-    border-radius: calc($radius / 2);
-    top: 50%;
-    transform: translateY(-50%);
-    right: 8px;
+    
+    &::after {
+      content: "\00a0";
+      position: absolute;
+      background-color: $primary-yellow;
+      width: $radius;
+      border-radius: calc($radius / 2);
+      height: 1.25rem;
+      top: 50%;
+      transform: translateY(-50%);
+      right: 8px;
+    }
   }
 }
 

--- a/src/scss/components/ss-menu.scss
+++ b/src/scss/components/ss-menu.scss
@@ -32,6 +32,9 @@ UL.ss-menu {
     background-color: $primary-yellow;
     width: $radius;
     border-radius: calc($radius / 2);
+    top: 50%;
+    transform: translateY(-50%);
+    right: 8px;
   }
 }
 


### PR DESCRIPTION
# Updated from last #2 
* Remove menu height
* Add more examples

# Overview

In my opinion, the menu item could other from `<a>`, and I want selected list can be easily to implement.
So, I make selected styles to be used with just `<li>`.

# Scope of work
Remove unused selected-box class and implement with `:after` on `<li>` instead of `<a>`.